### PR TITLE
Fixed favicon using config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ baseurl                  : # the subpath of your site, e.g. "/blog"
 repository               : # GitHub username/repo-name e.g. "mmistakes/minimal-mistakes"
 teaser                   : "/assets/images/Shledon_The FLash.jpg" # path of fallback teaser image, e.g. "/assets/images/500x300.png"
 logo                     : "/assets/favicon.png" # path of logo image to display in the masthead, e.g. "/assets/images/88x88.png"
-asset_url                : "/assets/<favicon.png>.<extension>"
+asset_url                : "/assets/favicon.png"
 masthead_title           : # overrides the website title displayed in the masthead, use " " for no title
 # breadcrumbs            : false # true, false (default)
 words_per_minute         : 200

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,19 +12,19 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="./assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 <link rel="shortcut icon" href="./favicon.ico">
 <link rel="shortcut icon" type="image/png" href="./favicon.png">
 <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="./favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="./favicon-16x16.png">
-<link rel="icon" type="image/png" href="./assets/favicon.png">
+<link rel="icon" type="image/png" href="{{ site.asset_url }}">
 <link rel="mask-icon" href="./safari-pinned-tab.svg" color="#5bbad5">
 <link rel="shortcut icon" href="./favicon.ico">
 <meta name="msapplication-TileColor" content="#da532c">
 <meta name="msapplication-config" content="./browserconfig.xml">
 <meta name="theme-color" content="#ffffff">
-<link href="/assets/favicon.png/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon"/>
+<link href="/assets/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon"/>
 
 <!--[if IE]>
   <style>


### PR DESCRIPTION
## Summary

The `<meta>` tag now uses `site.assets_url` from the `config.yml` file.

## Context

Follow-up on [StackOverflow question](https://stackoverflow.com/q/61629689/8080186).